### PR TITLE
Updated missing pip3 modules for macOS

### DIFF
--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -125,7 +125,8 @@ verify that pip3 is found in the correct place:
 
 Then run:
 
-    pip3 install lhafile pillow pyobjc pyqt5 requests
+    pip3 install lhafile pillow pyobjc pyqt5 requests typing_extensions \
+    rx
 
 And finally, from the fs-uae-launcher source directory:
 


### PR DESCRIPTION
Hi Frode,

I was following your excellent guide for compiling fs-uae-launcher. 
During compile I found that typing_extensions was missing from pip3.
During execution of compiled fs-uae-launcher I found that rx was missing from pip3.

I've added the two missing pip3 modules to the documentation for macOS. Unfortunately I don't have access to Linux or Microsoft OS'es, so I'm not sure if the modules are also needed for those OS'es.

Best regards,
Jacob