### PR TITLE
Fixes for Linux Mint 21.3 and Qt6

### DIFF
--- a/fsgamesys/plugins/pluginexecutablefinder.py
+++ b/fsgamesys/plugins/pluginexecutablefinder.py
@@ -1,5 +1,5 @@
 import platform
-from os import path
+from os import path, getenv
 from typing import Optional
 
 import fsboot
@@ -47,6 +47,9 @@ def find_executable(name: str):
         exe_file = find_executable_in_development_project_dir(name)
         if exe_file:
             return exe_file
+    exe_file = find_executable_in_path(name)
+    if exe_file:
+        return exe_file
     exe_file = find_executable_in_plugins_dir(name)
     if exe_file:
         return exe_file
@@ -62,6 +65,14 @@ def find_executable(name: str):
         return exe_file
     return None
 
+def find_executable_in_path(name: str):
+    print("- Find executable in system path")
+    paths = getenv("PATH", "").split(":")
+    for p in paths:
+        exe_file = path.join(p, get_exe_name(name))
+        if check_executable(exe_file):
+            return exe_file
+    return None
 
 def find_executable_in_development_project_dir(name: str):
     print("- Find executable in development project dir")

--- a/fsui/qt/font.py
+++ b/fsui/qt/font.py
@@ -1,4 +1,3 @@
-from tkinter.font import NORMAL
 from typing import Optional, Union
 
 from typing_extensions import TypedDict

--- a/fswidgets/splitter.py
+++ b/fswidgets/splitter.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from tkinter import HORIZONTAL
 from typing import List, Optional, cast
 
 from fsui import Widget

--- a/launcher/extra/glowicon.py
+++ b/launcher/extra/glowicon.py
@@ -190,8 +190,16 @@ def open_svg(path):
     # global _application
     # if _application is None:
     #     _application = QApplication(sys.argv)
+    qimage_version = QImage.__module__[0:5]
+    print(f"qimage_version: {qimage_version}")
+    if qimage_version == "PyQt6":
+        pixel_format = QImage.Format.Format_RGBA8888
+    elif qimage_version == "PyQt5":
+        pixel_format = QImage.Format_RGBA8888
+    else:
+        raise Exception("Invalid version of QImage: " + qimage_version)
     renderer = QSvgRenderer(path)
-    image = QImage(64, 64, QImage.Format_RGBA8888)
+    image = QImage(64, 64, pixel_format)
     image.fill(0x00000000)
     painter = QPainter(image)
     renderer.render(painter)


### PR DESCRIPTION
Recently tried to run fs-uae-launcher on my Linux Mint 21.3 system and had to make these updates to get it working.

Removed dependency on tkinter where not needed. Search paths set in PATH environment variable for fs-uae executable. Updates for Qt6 in glowicon.