### PR TITLE
Set desktop file name for the Qt application

### DIFF
--- a/fsui/qt/qt.py
+++ b/fsui/qt/qt.py
@@ -122,6 +122,7 @@ def init_qt():
 
     fsbc.desktop.set_open_url_in_browser_function(open_url_in_browser)
     qapplication = QApplication(sys.argv)
+    qapplication.setDesktopFileName("fs-uae-launcher")
     initialize_qt_style(qapplication)
     return qapplication
 


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `python3` (following the process name).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id